### PR TITLE
Assegnazione porte

### DIFF
--- a/connessioni/src/main/resources/application.yml
+++ b/connessioni/src/main/resources/application.yml
@@ -44,9 +44,8 @@ spring:
       batch-size: 0
 
 server:
-  port: ${PORT:${SERVER_PORT:0}}
   # Se necessario, puoi fissare una porta (es. 8080)
-  # port: 8080
+  port: 8080
   # Per Swagger, se dietro a un API Gateway
   forward-headers-strategy: framework
 

--- a/recensioni-seguite/src/main/resources/application.yml
+++ b/recensioni-seguite/src/main/resources/application.yml
@@ -48,8 +48,8 @@ spring:
     show-sql: false
 
 server: 
-  port: ${PORT:${SERVER_PORT:0}}
-#  port: 8080
+  
+  port: 8080
   # per swagger, se dietro a un api gateway 
   forward-headers-strategy: framework
 asw:

--- a/recensioni/src/main/resources/application.yml
+++ b/recensioni/src/main/resources/application.yml
@@ -44,9 +44,8 @@ spring:
       batch-size: 0
 
 server:
-  port: ${PORT:${SERVER_PORT:0}}
   # Se necessario, puoi fissare una porta (es. 8080)
-  # port: 8080
+  port: 8080
   # Per Swagger, se dietro a un API Gateway
   forward-headers-strategy: framework
 


### PR DESCRIPTION
Ora che usiamo docker non è più necessario assegnare le porte in modo… randomico. Per semplicità utilizziamo sempre la porta 8080